### PR TITLE
Update spec imports for renamed components

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,23 +1,24 @@
 import { TestBed } from '@angular/core/testing';
-import { App } from './app';
+import { AppComponent } from './app';
 
-describe('App', () => {
+describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App],
+      imports: [AppComponent],
     }).compileComponents();
   });
 
   it('should create the app', () => {
-    const fixture = TestBed.createComponent(App);
+    const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it('should render title', () => {
-    const fixture = TestBed.createComponent(App);
+    const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, angular-list-app');
+    const appInstance = fixture.componentInstance;
+    expect(compiled.querySelector('h1')?.textContent).toContain(`Hello, ${appInstance.title}`);
   });
 });

--- a/src/app/items-list.spec.ts
+++ b/src/app/items-list.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { ItemsList } from './items-list';
+import { ItemsListComponent } from './items-list';
 
-describe('ItemsList', () => {
-  let component: ItemsList;
-  let fixture: ComponentFixture<ItemsList>;
+describe('ItemsListComponent', () => {
+  let component: ItemsListComponent;
+  let fixture: ComponentFixture<ItemsListComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ItemsList]
+      imports: [ItemsListComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(ItemsList);
+    fixture = TestBed.createComponent(ItemsListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });


### PR DESCRIPTION
## Summary
- fix test component imports to use `AppComponent` and `ItemsListComponent`
- adjust the heading test in `AppComponent` spec to match the template

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609d05137c832abc404491b94e000d